### PR TITLE
Issue 17 solved

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
     "rules": {
         "no-tabs": ["error", { "allowIndentationTabs": true }],
 		"indent": ["error", "tab", {"SwitchCase": 1}],
-		"no-console": "off"
+		"no-console": "off",
+		"no-await-in-loop": "off"
     }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"scripts": {
 		"start": "node src/index.js",
 		"dev": "nodemon src/index.js",
-		"test": "jest --collectCoverage",
+		"test": "jest --collectCoverage --silent",
 		"lint": "eslint src",
 		"uglify": "uglifyjs-folder src -eo build",
 		"build": "npm run test && npm run lint && npm run uglify"

--- a/src/commandsHandler.js
+++ b/src/commandsHandler.js
@@ -2,7 +2,7 @@ const CommandsEnum = require('./enums/CommandsEnums');
 const TemplateHandler = require('./templateHandler');
 
 module.exports = {
-	handleCommand(message, BOT_PREFIX) {
+	async handleCommand(message, BOT_PREFIX) {
 		const isAdmin = message.member.hasPermission('ADMINISTRATOR');
 		if (message.content.toString()[0] === BOT_PREFIX && isAdmin) {
 			const args = message.content.slice(BOT_PREFIX.length).trim().split(/ +/);
@@ -21,6 +21,14 @@ module.exports = {
 					TemplateHandler.executeTemplate(templateName, templateSize, templateLang, message);
 					break;
 				}
+
+				// Only for testing purposes
+				case CommandsEnum.RESET_GUILD:
+					message.guild.roles.cache.find(role => {if (role.name === "Member" || role.name === "Membro")  role.delete(); });
+					message.guild.roles.cache.find(role => {if (role.name === "Mods" || role.name === "Moderação") role.delete(); });
+					message.guild.channels.cache.each(async (channel) => await channel.delete());
+					await message.guild.channels.create("Chronobreak");
+					break;
 
 				default:
 					message.channel.send('Command not recognized.');

--- a/src/commandsHandler.js
+++ b/src/commandsHandler.js
@@ -2,7 +2,7 @@ const CommandsEnum = require('./enums/CommandsEnums');
 const TemplateHandler = require('./templateHandler');
 
 module.exports = {
-	async handleCommand(message, BOT_PREFIX) {
+	handleCommand(message, BOT_PREFIX) {
 		const isAdmin = message.member.hasPermission('ADMINISTRATOR');
 		if (message.content.toString()[0] === BOT_PREFIX && isAdmin) {
 			const args = message.content.slice(BOT_PREFIX.length).trim().split(/ +/);
@@ -22,13 +22,19 @@ module.exports = {
 					break;
 				}
 
-				// Only for testing purposes
+				// Only for internal testing purposes
+				/*
 				case CommandsEnum.RESET_GUILD:
-					message.guild.roles.cache.find(role => {if (role.name === "Member" || role.name === "Membro")  role.delete(); });
-					message.guild.roles.cache.find(role => {if (role.name === "Mods" || role.name === "Moderação") role.delete(); });
-					message.guild.channels.cache.each(async (channel) => await channel.delete());
-					await message.guild.channels.create("Chronobreak");
+					message.guild.roles.cache.each((role) => {
+						if (role.name === 'Member' || role.name === 'Membro') role.delete();
+					});
+					message.guild.roles.cache.each((role) => {
+						if (role.name === 'Mods' || role.name === 'Moderação') role.delete();
+					});
+					message.guild.channels.cache.each((channel) => channel.delete());
+					message.guild.channels.create('Chronobreak');
 					break;
+				*/
 
 				default:
 					message.channel.send('Command not recognized.');

--- a/src/commandsHandler.js
+++ b/src/commandsHandler.js
@@ -18,7 +18,7 @@ module.exports = {
 					const templateSize = args[1];
 					const templateLang = args[2];
 
-					TemplateHandler.executeTemplate(templateName, templateSize, templateLang);
+					TemplateHandler.executeTemplate(templateName, templateSize, templateLang, message);
 					break;
 				}
 

--- a/src/enums/CommandsEnums.js
+++ b/src/enums/CommandsEnums.js
@@ -1,7 +1,7 @@
 const commands = {
 	HELLO: 'hello',
 	TEMPLATE: 'template',
-	RESET_GUILD: 'reset'
+	RESET_GUILD: 'reset',
 };
 
 const CommandsEnum = Object.freeze(commands);

--- a/src/enums/CommandsEnums.js
+++ b/src/enums/CommandsEnums.js
@@ -1,6 +1,7 @@
 const commands = {
 	HELLO: 'hello',
 	TEMPLATE: 'template',
+	RESET_GUILD: 'reset'
 };
 
 const CommandsEnum = Object.freeze(commands);

--- a/src/enums/TemplateLangEnums.js
+++ b/src/enums/TemplateLangEnums.js
@@ -1,6 +1,6 @@
 const templateLang = {
-	PT_BR: 'portuguese-br',
-	EN: 'english',
+	PT_BR: 'PT_BR',
+	EN: 'EN',
 };
 
 const TemplateLangEnum = Object.freeze(templateLang);

--- a/src/index.js
+++ b/src/index.js
@@ -15,10 +15,10 @@ client.on(Events.READY, () => {
 	console.log(`Your Discord bot invite: https://discord.com/oauth2/authorize?client_id=${process.env.DISCORD_ID}&scope=bot&permissions=8`);
 });
 
-client.on(Events.MESSAGE, async (message) => {
+client.on(Events.MESSAGE, (message) => {
 	const prefix = process.env.BOT_PREFIX;
 	checkPrefix(prefix);
-	await handleCommand(message, prefix);
+	handleCommand(message, prefix);
 });
 
 client.login(process.env.DISCORD_TOKEN);

--- a/src/index.js
+++ b/src/index.js
@@ -15,10 +15,10 @@ client.on(Events.READY, () => {
 	console.log(`Your Discord bot invite: https://discord.com/oauth2/authorize?client_id=${process.env.DISCORD_ID}&scope=bot&permissions=8`);
 });
 
-client.on(Events.MESSAGE, (message) => {
+client.on(Events.MESSAGE, async (message) => {
 	const prefix = process.env.BOT_PREFIX;
 	checkPrefix(prefix);
-	handleCommand(message, prefix);
+	await handleCommand(message, prefix);
 });
 
 client.login(process.env.DISCORD_TOKEN);

--- a/src/templateHandler.js
+++ b/src/templateHandler.js
@@ -1,10 +1,140 @@
-// const TemplateEnum = require('./enums/TemplateEnums');
-// const TemplateSizeEnum = require('./enums/TemplateSizeEnums');
-// const TemplateLangEnum = require('./enums/TemplateLangEnums');
+const TemplateEnum = require('./enums/TemplateEnums');
+const TemplateSizeEnum = require('./enums/TemplateSizeEnums');
+const TemplateLangEnum = require('./enums/TemplateLangEnums');
+
+const DEFAULT_TEMPLATE_JSON = require('./templates/default.json');
 
 module.exports = {
-	executeTemplate() {
-		// Imports and params commented to avoid lint errors as the implementation
-		// isn't part of this Issue.
+	async executeTemplate(templateName, templateSize, templateLang, message) {
+		const SELECTED_TEMPLATE = selectedTemplate(templateName);
+		const SELECTED_SIZE = selectedSize(templateSize);
+		const SELECTED_LANG = selectedLang(templateLang);
+
+		//await createRoles(SELECTED_TEMPLATE.roles, SELECTED_LANG, message);
+		await createChannels(SELECTED_TEMPLATE.channels, SELECTED_SIZE, SELECTED_LANG, message);
 	},
 };
+
+function selectedTemplate(templateName) {
+	const tname = templateName || "";
+
+	switch (tname.toLowerCase()) {
+		case TemplateEnum.DEFAULT:
+			return DEFAULT_TEMPLATE_JSON;
+
+		default:
+			return DEFAULT_TEMPLATE_JSON;
+	}
+}
+
+function selectedSize(templateSize) {
+	const tsize = templateSize || "";
+
+	switch (tsize.toLowerCase()) {
+		case TemplateSizeEnum.SMALL:
+			return 1;
+
+		case TemplateSizeEnum.MEDIUM:
+			return 2;
+
+		case TemplateSizeEnum.BIG:
+			return 3;
+
+		case TemplateSizeEnum.GIANT:
+			return 4;
+	
+		default:
+			return TemplateSizeEnum.SMALL;
+	}
+}
+
+function selectedLang(templateLang) {
+	const tlang = templateLang || "";
+
+	switch (tlang.toUpperCase()) {
+		case TemplateLangEnum.PT_BR:
+			return TemplateLangEnum.PT_BR;
+
+		case TemplateLangEnum.EN:
+			return TemplateLangEnum.EN;
+	
+		default:
+			return TemplateLangEnum.EN;
+	}
+}
+
+async function createRoles(roles, lang, message) {
+	roles.forEach(async (role) => {
+		try {
+			await message.guild.roles.create({
+				data: {
+					name: role.name[lang],
+					color: role.color,
+					position: role.position,
+					permissions: role.permissions,
+					mentionable: role.mentionable,
+					hoist: role.hoist
+				}
+			});
+		} catch (error) {
+			console.log(error);
+			message.channel.send('Discord API Error on creating roles.');
+		}
+	});
+}
+
+async function createChannels(channels, size, lang, message, parent, stackCount) {
+	let internalSC = stackCount || 0;
+
+	for (let i = 0; i < channels.length; i++) {
+		try {
+			const channelConfig = await adjustChannelObject(channels[i], lang, message.guild, parent);
+			const channelCreated = await message.guild.channels.create(
+				channels[i].name[lang],
+				channelConfig.data
+			);
+
+			if (channelConfig.child) {
+				await createChannels(channelConfig.child, size, lang, message, channelCreated);
+			}
+
+			if (channels[i].scalable) {
+				let SC = internalSC + 1;
+
+				if (SC <= size) {
+					await createChannels(channels, size, lang, message, null, SC);
+				}
+			}
+		} catch (error) {
+			console.log(error);
+			message.channel.send('Discord API Error on creating channels.');
+		}
+	}
+}
+
+async function adjustChannelObject(channel, lang, guild, parent) {
+	const channelObj = {};
+
+	channelObj.data = {
+		type: channel.type,
+		permissionOverwrites: [],
+		parent: parent
+	}
+
+	// Get fresh info about the roles created before.
+	const freshRoles = await guild.roles.fetch();
+
+	if (channel.permissionOverwrites.length) {
+		channel.permissionOverwrites.forEach((po) => {
+			let roleName = freshRoles.cache.find(role => role.name === po.name[lang]);
+			channelObj.data.permissionOverwrites.push({
+				id: roleName,
+				allow: po.allow,
+				deny: po.deny
+			})
+		});
+	}
+
+	channelObj.child = channel.child;
+	return channelObj;
+}

--- a/src/templateHandler.js
+++ b/src/templateHandler.js
@@ -4,142 +4,142 @@ const TemplateLangEnum = require('./enums/TemplateLangEnums');
 
 const DEFAULT_TEMPLATE_JSON = require('./templates/default.json');
 
-function selectedTemplate(templateName) {
-	const tname = templateName || '';
-
-	switch (tname.toLowerCase()) {
-		case TemplateEnum.DEFAULT:
-			return DEFAULT_TEMPLATE_JSON;
-
-		default:
-			return DEFAULT_TEMPLATE_JSON;
-	}
-}
-
-function selectedSize(templateSize) {
-	const tsize = templateSize || '';
-
-	switch (tsize.toLowerCase()) {
-		case TemplateSizeEnum.SMALL:
-			return 1;
-
-		case TemplateSizeEnum.MEDIUM:
-			return 2;
-
-		case TemplateSizeEnum.BIG:
-			return 3;
-
-		case TemplateSizeEnum.GIANT:
-			return 4;
-
-		default:
-			return TemplateSizeEnum.SMALL;
-	}
-}
-
-function selectedLang(templateLang) {
-	const tlang = templateLang || '';
-
-	switch (tlang.toUpperCase()) {
-		case TemplateLangEnum.PT_BR:
-			return TemplateLangEnum.PT_BR;
-
-		case TemplateLangEnum.EN:
-			return TemplateLangEnum.EN;
-
-		default:
-			return TemplateLangEnum.EN;
-	}
-}
-
-async function createRoles(roles, lang, message) {
-	roles.forEach(async (role) => {
-		try {
-			await message.guild.roles.create({
-				data: {
-					name: role.name[lang],
-					color: role.color,
-					position: role.position,
-					permissions: role.permissions,
-					mentionable: role.mentionable,
-					hoist: role.hoist,
-				},
-			});
-		} catch (error) {
-			console.log(error);
-			message.channel.send('Discord API Error on creating roles.');
-		}
-	});
-}
-
-async function adjustChannelObject(channel, lang, guild, parent) {
-	const channelObj = {};
-
-	channelObj.data = {
-		type: channel.type,
-		permissionOverwrites: [],
-		parent,
-	};
-
-	try {
-		// Get fresh info about the roles created before.
-		const freshRoles = await guild.roles.fetch();
-	
-		if (channel.permissionOverwrites.length) {
-			channel.permissionOverwrites.forEach((po) => {
-				const roleName = freshRoles.cache.find((role) => role.name === po.name[lang]);
-				channelObj.data.permissionOverwrites.push({
-					id: roleName,
-					allow: po.allow,
-					deny: po.deny,
-				});
-			});
-		}
-	} catch (error) {
-		console.log(error);
-		message.channel.send('Discord API Error on getting roles.');
-	}
-
-	channelObj.child = channel.child;
-	return channelObj;
-}
-
-async function createChannels(channels, size, lang, message, parent, stackCount) {
-	const internalSC = stackCount || 0;
-
-	for (let i = 0; i < channels.length; i += 1) {
-		const channelConfig = await adjustChannelObject(channels[i], lang, message.guild, parent);
-		try {
-			const channelCreated = await message.guild.channels.create(
-				channels[i].name[lang],
-				channelConfig.data,
-			);
-
-			if (channelConfig.child) {
-				await createChannels(channelConfig.child, size, lang, message, channelCreated);
-			}
-
-			if (channels[i].scalable) {
-				const SC = internalSC + 1;
-
-				if (SC < size) {
-					await createChannels([channels[i]], size, lang, message, null, SC);
-				}
-			}
-		} catch (error) {
-			console.log(error);
-			message.channel.send('Discord API Error on creating channels.');
-		}
-	}
-}
-
 module.exports = {
-	async executeTemplate(templateName, templateSize, templateLang, message) {
-		const SELECTED_TEMPLATE = selectedTemplate(templateName);
-		const SELECTED_SIZE = selectedSize(templateSize);
-		const SELECTED_LANG = selectedLang(templateLang);
+	selectedTemplate(templateName) {
+		const tname = templateName || '';
 
-		await createRoles(SELECTED_TEMPLATE.roles, SELECTED_LANG, message);
-		await createChannels(SELECTED_TEMPLATE.channels, SELECTED_SIZE, SELECTED_LANG, message);
+		switch (tname.toLowerCase()) {
+			case TemplateEnum.DEFAULT:
+				return DEFAULT_TEMPLATE_JSON;
+
+			default:
+				return DEFAULT_TEMPLATE_JSON;
+		}
+	},
+
+	selectedSize(templateSize) {
+		const tsize = templateSize || '';
+
+		switch (tsize.toLowerCase()) {
+			case TemplateSizeEnum.SMALL:
+				return 1;
+
+			case TemplateSizeEnum.MEDIUM:
+				return 2;
+
+			case TemplateSizeEnum.BIG:
+				return 3;
+
+			case TemplateSizeEnum.GIANT:
+				return 4;
+
+			default:
+				return 1;
+		}
+	},
+
+	selectedLang(templateLang) {
+		const tlang = templateLang || '';
+
+		switch (tlang.toUpperCase()) {
+			case TemplateLangEnum.PT_BR:
+				return TemplateLangEnum.PT_BR;
+
+			case TemplateLangEnum.EN:
+				return TemplateLangEnum.EN;
+
+			default:
+				return TemplateLangEnum.EN;
+		}
+	},
+
+	async createRoles(roles, lang, message) {
+		roles.forEach(async (role) => {
+			try {
+				await message.guild.roles.create({
+					data: {
+						name: role.name[lang],
+						color: role.color,
+						position: role.position,
+						permissions: role.permissions,
+						mentionable: role.mentionable,
+						hoist: role.hoist,
+					},
+				});
+			} catch (error) {
+				console.log(error);
+				message.channel.send('Discord API Error on creating roles.');
+			}
+		});
+	},
+
+	async adjustChannelObject(channel, lang, message, parent) {
+		const channelObj = {};
+
+		channelObj.data = {
+			type: channel.type,
+			permissionOverwrites: [],
+			parent,
+		};
+
+		try {
+			// Get fresh info about the roles created before.
+			const freshRoles = await message.guild.roles.fetch();
+
+			if (channel.permissionOverwrites.length) {
+				channel.permissionOverwrites.forEach((po) => {
+					const roleName = freshRoles.cache.find((role) => role.name === po.name[lang]);
+					channelObj.data.permissionOverwrites.push({
+						id: roleName,
+						allow: po.allow,
+						deny: po.deny,
+					});
+				});
+			}
+		} catch (error) {
+			console.log(error);
+			message.channel.send('Discord API Error on getting roles.');
+		}
+
+		channelObj.child = channel.child;
+		return channelObj;
+	},
+
+	async createChannels(channels, size, lang, message, parent, stackCount) {
+		const internalSC = stackCount || 0;
+
+		for (let i = 0; i < channels.length; i += 1) {
+			const channelConfig = await this.adjustChannelObject(channels[i], lang, message, parent);
+			try {
+				const channelCreated = await message.guild.channels.create(
+					channels[i].name[lang],
+					channelConfig.data,
+				);
+
+				if (channelConfig.child) {
+					await this.createChannels(channelConfig.child, size, lang, message, channelCreated);
+				}
+
+				if (channels[i].scalable) {
+					const SC = internalSC + 1;
+
+					if (SC < size) {
+						await this.createChannels([channels[i]], size, lang, message, null, SC);
+					}
+				}
+			} catch (error) {
+				console.log(error);
+				message.channel.send('Discord API Error on creating channels.');
+			}
+		}
+	},
+
+	async executeTemplate(templateName, templateSize, templateLang, message) {
+		const SELECTED_TEMPLATE = this.selectedTemplate(templateName);
+		const SELECTED_SIZE = this.selectedSize(templateSize);
+		const SELECTED_LANG = this.selectedLang(templateLang);
+
+		await this.createRoles(SELECTED_TEMPLATE.roles, SELECTED_LANG, message);
+		await this.createChannels(SELECTED_TEMPLATE.channels, SELECTED_SIZE, SELECTED_LANG, message);
 	},
 };

--- a/src/templates/default.json
+++ b/src/templates/default.json
@@ -27,7 +27,6 @@
     ],
     "channels": [
         {
-            "id": "0",
             "name": {
 				"PT_BR": "Informações",
 				"EN": "Info"
@@ -41,11 +40,18 @@
 					},
 					"allow": [],
 					"deny": ["SEND_MESSAGES"]
+				},
+				{
+					"name": {
+						"PT_BR": "Moderação",
+						"EN": "Mods"
+					},
+					"allow": ["SEND_MESSAGES"],
+					"deny": []
 				}
 			],
             "child": [
                 {
-                    "id": "0.1",
                     "name": {
 						"PT_BR": "bem-vindo",
 						"EN": "welcome"
@@ -54,7 +60,6 @@
 					"permissionOverwrites": []
                 },
                 {
-                    "id": "0.2",
                     "name": {
 						"PT_BR": "regras",
 						"EN": "rules"
@@ -63,7 +68,6 @@
 					"permissionOverwrites": []
                 },
                 {
-                    "id": "0.3",
                     "name": {
 						"PT_BR": "ajuda",
 						"EN": "need-help"
@@ -72,7 +76,6 @@
 					"permissionOverwrites": []
                 },
                 {
-                    "id": "0.4",
                     "name": {
 						"PT_BR": "anúncios",
 						"EN": "announcements"
@@ -83,7 +86,6 @@
             ]
         },
         {
-            "id": "1",
             "name": {
 				"PT_BR": "Lobby-1",
 				"EN": "Lobby-1"
@@ -93,7 +95,6 @@
 			"permissionOverwrites": [],
             "child": [
                 {
-                    "id": "1.1",
                     "name": {
 						"PT_BR": "nome-temporario-1",
 						"EN": "temporary-name-1"
@@ -102,7 +103,6 @@
 					"permissionOverwrites": []
                 },
                 {
-                    "id": "1.2",
                     "name": {
 						"PT_BR": "nome-temporario-2",
 						"EN": "temporary-name-2"
@@ -111,7 +111,6 @@
 					"permissionOverwrites": []
                 },
                 {
-                    "id": "1.3",
                     "name": {
 						"PT_BR": "nome-temporario-3",
 						"EN": "temporary-name-3"
@@ -120,15 +119,16 @@
 					"permissionOverwrites": []
                 },
                 {
-                    "id": "1.4",
-                    "name": "nome-temporario-audio",
+                    "name": {
+						"PT_BR": "nome-temporario-audio",
+						"EN": "temporary-name-audio"
+					},
                     "type": "voice",
 					"permissionOverwrites": []
                 }
             ]
         },
         {
-            "id": "2",
             "name": {
 				"PT_BR": "Moderação",
 				"EN": "Moderation"
@@ -142,11 +142,18 @@
 					},
 					"allow": [],
 					"deny": ["VIEW_CHANNEL"]
+				},
+				{
+					"name": {
+						"PT_BR": "Moderação",
+						"EN": "Mods"
+					},
+					"allow": ["VIEW_CHANNEL"],
+					"deny": []
 				}
 			],
             "child": [
                 {
-                    "id": "2.1",
                     "name": {
 						"PT_BR": "usuarios-entraram",
 						"EN": "users-joined"
@@ -155,7 +162,6 @@
 					"permissionOverwrites": []
                 },
                 {
-                    "id": "2.2",
                     "name": {
 						"PT_BR": "usuarios-sairam",
 						"EN": "users-left"
@@ -164,16 +170,14 @@
 					"permissionOverwrites": []
                 },
                 {
-                    "id": "2.3",
                     "name": {
 						"PT_BR": "chat-moderadores",
-						"EN": "chat-moderators"
+						"EN": "chat-mods"
 					},
                     "type": "text",
 					"permissionOverwrites": []
                 },
                 {
-                    "id": "2.4",
                     "name": {
 						"PT_BR": "sala-de-reuniões",
 						"EN": "meeting-room"

--- a/src/templates/default.json
+++ b/src/templates/default.json
@@ -1,0 +1,193 @@
+{
+    "id": 1,
+    "name": "Default Template",
+	"roles": [
+        {
+            "name": {
+				"PT_BR": "Moderação",
+				"EN": "Mods"
+			},
+			"color": "#0985c5",
+			"position": 1,
+            "permissions": 4260888183,
+			"hoist": true,
+			"mentionable": false
+        },
+        {
+            "name": {
+				"PT_BR": "Membro",
+				"EN": "Member"
+			},
+			"color": "#1e8f36",
+			"position": 0,
+            "permissions": 70372929,
+			"hoist": false,
+			"mentionable": true
+        }
+    ],
+    "channels": [
+        {
+            "id": "0",
+            "name": {
+				"PT_BR": "Informações",
+				"EN": "Info"
+			},
+            "type": "category",
+            "permissionOverwrites": [
+				{
+					"name": {
+						"PT_BR": "Membro",
+						"EN": "Member"
+					},
+					"allow": [],
+					"deny": ["SEND_MESSAGES"]
+				}
+			],
+            "child": [
+                {
+                    "id": "0.1",
+                    "name": {
+						"PT_BR": "bem-vindo",
+						"EN": "welcome"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "id": "0.2",
+                    "name": {
+						"PT_BR": "regras",
+						"EN": "rules"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "id": "0.3",
+                    "name": {
+						"PT_BR": "ajuda",
+						"EN": "need-help"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "id": "0.4",
+                    "name": {
+						"PT_BR": "anúncios",
+						"EN": "announcements"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                }
+            ]
+        },
+        {
+            "id": "1",
+            "name": {
+				"PT_BR": "Lobby-1",
+				"EN": "Lobby-1"
+			},
+            "type": "category",
+            "scalable": true,
+			"permissionOverwrites": [],
+            "child": [
+                {
+                    "id": "1.1",
+                    "name": {
+						"PT_BR": "nome-temporario-1",
+						"EN": "temporary-name-1"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "id": "1.2",
+                    "name": {
+						"PT_BR": "nome-temporario-2",
+						"EN": "temporary-name-2"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "id": "1.3",
+                    "name": {
+						"PT_BR": "nome-temporario-3",
+						"EN": "temporary-name-3"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "id": "1.4",
+                    "name": "nome-temporario-audio",
+                    "type": "voice",
+					"permissionOverwrites": []
+                }
+            ]
+        },
+        {
+            "id": "2",
+            "name": {
+				"PT_BR": "Moderação",
+				"EN": "Moderation"
+			},
+            "type": "category",
+			"permissionOverwrites": [
+				{
+					"name": {
+						"PT_BR": "Membro",
+						"EN": "Member"
+					},
+					"allow": [],
+					"deny": ["VIEW_CHANNEL"]
+				}
+			],
+            "child": [
+                {
+                    "id": "2.1",
+                    "name": {
+						"PT_BR": "usuarios-entraram",
+						"EN": "users-joined"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "id": "2.2",
+                    "name": {
+						"PT_BR": "usuarios-sairam",
+						"EN": "users-left"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "id": "2.3",
+                    "name": {
+						"PT_BR": "chat-moderadores",
+						"EN": "chat-moderators"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "id": "2.4",
+                    "name": {
+						"PT_BR": "sala-de-reuniões",
+						"EN": "meeting-room"
+					},
+                    "type": "voice",
+					"permissionOverwrites": []
+                }
+            ]
+        }
+    ],
+    "modules": [
+        {
+            "id": 5,
+            "config": {}
+        }
+    ]
+}

--- a/tests/commandsHandler.test.js
+++ b/tests/commandsHandler.test.js
@@ -71,5 +71,5 @@ test('Template command should call the right handler.', () => {
 
 	const executeTemplateSpy = jest.spyOn(templateHandler, 'executeTemplate');
     handleCommand(message, botPrefix);
-    expect(executeTemplateSpy).toHaveBeenCalledWith('kappa', 'fon', 'trab');
+    expect(executeTemplateSpy).toHaveBeenCalledWith('kappa', 'fon', 'trab', message);
 });

--- a/tests/templateHandler.test.js
+++ b/tests/templateHandler.test.js
@@ -1,0 +1,643 @@
+const templateHandler = require('../src/templateHandler');
+const TemplateLangEnum = require('../src/enums/TemplateLangEnums');
+const DEFAULT_TEMPLATE_JSON = require('../src/templates/default.json');
+
+afterEach(() => {    
+	jest.clearAllMocks();
+});
+
+test('selectedTemplate - should return the right template json.', () => {
+	let templateName = 'default';
+	let r = templateHandler.selectedTemplate(templateName);
+    expect(r).toBe(DEFAULT_TEMPLATE_JSON);
+
+	templateName = 'DEFAULT';
+	r = templateHandler.selectedTemplate(templateName);
+    expect(r).toBe(DEFAULT_TEMPLATE_JSON);
+});
+
+test('selectedTemplate - should return the default template json if theres no match.', () => {
+	let templateName = '';
+	let r = templateHandler.selectedTemplate(templateName);
+    expect(r).toBe(DEFAULT_TEMPLATE_JSON);
+
+	templateName = null;
+	r = templateHandler.selectedTemplate(templateName);
+    expect(r).toBe(DEFAULT_TEMPLATE_JSON);
+});
+
+test('selectedSize - should return the right size number.', () => {
+	let templateSize = 'small';
+	let r = templateHandler.selectedSize(templateSize);
+    expect(r).toBe(1);
+
+	templateName = 'SMALL';
+	r = templateHandler.selectedSize(templateName);
+    expect(r).toBe(1);
+
+	templateName = 'medium';
+	r = templateHandler.selectedSize(templateName);
+    expect(r).toBe(2);
+
+	templateSize = 'MEDIUM';
+	r = templateHandler.selectedSize(templateSize);
+    expect(r).toBe(2);
+
+	templateName = 'big';
+	r = templateHandler.selectedSize(templateName);
+    expect(r).toBe(3);
+
+	templateSize = 'BIG';
+	r = templateHandler.selectedSize(templateSize);
+    expect(r).toBe(3);
+
+	templateName = 'giant';
+	r = templateHandler.selectedSize(templateName);
+    expect(r).toBe(4);
+
+	templateSize = 'GIANT';
+	r = templateHandler.selectedSize(templateSize);
+    expect(r).toBe(4);
+});
+
+test('selectedSize - should return the default size number if theres no match.', () => {
+	let templateSize = '';
+	let r = templateHandler.selectedSize(templateSize);
+    expect(r).toBe(1);
+
+	templateSize = null;
+	r = templateHandler.selectedSize(templateSize);
+    expect(r).toBe(1);
+});
+
+test('selectedLang - should return the right language string.', () => {
+	let templateLang = 'pt_br';
+	let r = templateHandler.selectedLang(templateLang);
+    expect(r).toBe(TemplateLangEnum.PT_BR);
+
+	templateLang = 'PT_BR';
+	r = templateHandler.selectedLang(templateLang);
+    expect(r).toBe(TemplateLangEnum.PT_BR);
+
+	templateLang = 'en';
+	r = templateHandler.selectedLang(templateLang);
+    expect(r).toBe(TemplateLangEnum.EN);
+
+	templateLang = 'EN';
+	r = templateHandler.selectedLang(templateLang);
+    expect(r).toBe(TemplateLangEnum.EN);
+});
+
+test('selectedLang - should return the default template json if theres no match.', () => {
+	let templateLang = '';
+	let r = templateHandler.selectedLang(templateLang);
+    expect(r).toBe(TemplateLangEnum.EN);
+
+	templateLang = null;
+	r = templateHandler.selectedLang(templateLang);
+    expect(r).toBe(TemplateLangEnum.EN);
+});
+
+test('createRoles - should call the discord API with the right params (EN).', async () => {
+	const roles = [
+        {
+            "name": {
+				"PT_BR": "Moderação",
+				"EN": "Mods"
+			},
+			"color": "#0985c5",
+			"position": 1,
+            "permissions": 4260888183,
+			"hoist": true,
+			"mentionable": false
+        },
+        {
+            "name": {
+				"PT_BR": "Membro",
+				"EN": "Member"
+			},
+			"color": "#1e8f36",
+			"position": 0,
+            "permissions": 70372929,
+			"hoist": false,
+			"mentionable": true
+        }
+    ];
+	const message = {
+        channel: {
+            send: jest.fn(() => { return 42; })
+        },
+		guild: {
+			roles: {
+				create: jest.fn(() => { return true; })
+			}
+		}
+    }
+
+	const createRolesSpy = jest.spyOn(message.guild.roles, 'create');
+	await templateHandler.createRoles(roles, 'EN', message);
+
+	expect(createRolesSpy).toHaveBeenCalledTimes(2);
+    expect(createRolesSpy).toHaveBeenCalledWith({
+		data: {
+			name: roles[0].name['EN'],
+			color: roles[0].color,
+			position: roles[0].position,
+			permissions: roles[0].permissions,
+			mentionable: roles[0].mentionable,
+			hoist: roles[0].hoist, 
+		}
+	});
+
+	expect(createRolesSpy).toHaveBeenCalledWith({
+		data: {
+			name: roles[1].name['EN'],
+			color: roles[1].color,
+			position: roles[1].position,
+			permissions: roles[1].permissions,
+			mentionable: roles[1].mentionable,
+			hoist: roles[1].hoist, 
+		}
+	});
+});
+
+test('createRoles - should call the discord API with the right params (PT_BR).', async () => {
+	const roles = [
+        {
+            "name": {
+				"PT_BR": "Moderação",
+				"EN": "Mods"
+			},
+			"color": "#0985c5",
+			"position": 1,
+            "permissions": 4260888183,
+			"hoist": true,
+			"mentionable": false
+        },
+        {
+            "name": {
+				"PT_BR": "Membro",
+				"EN": "Member"
+			},
+			"color": "#1e8f36",
+			"position": 0,
+            "permissions": 70372929,
+			"hoist": false,
+			"mentionable": true
+        }
+    ];
+	const message = {
+        channel: {
+            send: jest.fn(() => { return 42; })
+        },
+		guild: {
+			roles: {
+				create: jest.fn(() => { return true; })
+			}
+		}
+    }
+
+	const createRolesSpy = jest.spyOn(message.guild.roles, 'create');
+	await templateHandler.createRoles(roles, 'PT_BR', message);
+
+	expect(createRolesSpy).toHaveBeenCalledTimes(2);
+    expect(createRolesSpy).toHaveBeenCalledWith({
+		data: {
+			name: roles[0].name['PT_BR'],
+			color: roles[0].color,
+			position: roles[0].position,
+			permissions: roles[0].permissions,
+			mentionable: roles[0].mentionable,
+			hoist: roles[0].hoist, 
+		}
+	});
+
+	expect(createRolesSpy).toHaveBeenCalledWith({
+		data: {
+			name: roles[1].name['PT_BR'],
+			color: roles[1].color,
+			position: roles[1].position,
+			permissions: roles[1].permissions,
+			mentionable: roles[1].mentionable,
+			hoist: roles[1].hoist, 
+		}
+	});
+});
+
+test('createRoles - should send the right message if any error got catched.', async () => {
+	const roles = [
+        {
+            "name": {
+				"PT_BR": "Moderação",
+				"EN": "Mods"
+			},
+			"color": "#0985c5",
+			"position": 1,
+            "permissions": 4260888183,
+			"hoist": true,
+			"mentionable": false
+        },
+        {
+            "name": {
+				"PT_BR": "Membro",
+				"EN": "Member"
+			},
+			"color": "#1e8f36",
+			"position": 0,
+            "permissions": 70372929,
+			"hoist": false,
+			"mentionable": true
+        }
+    ];
+	const message = {
+        channel: {
+            send: jest.fn(() => { return 42; })
+        },
+		guild: {
+			roles: {
+				create: jest.fn(() => { throw "ERRROU!"; })
+			}
+		}
+    };
+
+	const messageSentSpy = jest.spyOn(message.channel, 'send');
+	await templateHandler.createRoles(roles, 'EN', message);
+
+	expect(messageSentSpy).toHaveBeenCalledTimes(2);
+	expect(messageSentSpy).toHaveBeenCalledWith('Discord API Error on creating roles.');
+});
+
+test('adjustChannelObject - Should return the right object for the channel creation.', async () => {
+	const channel = {
+		"name": {
+			"PT_BR": "Informações",
+			"EN": "Info"
+		},
+		"type": "category",
+		"permissionOverwrites": [
+			{
+				"name": {
+					"PT_BR": "Membro",
+					"EN": "Member"
+				},
+				"allow": [],
+				"deny": ["SEND_MESSAGES"]
+			},
+			{
+				"name": {
+					"PT_BR": "Moderação",
+					"EN": "Mods"
+				},
+				"allow": ["SEND_MESSAGES"],
+				"deny": []
+			}
+		],
+		"child": [
+			{
+				"name": {
+					"PT_BR": "bem-vindo",
+					"EN": "welcome"
+				},
+				"type": "text",
+				"permissionOverwrites": []
+			},
+			{
+				"name": {
+					"PT_BR": "regras",
+					"EN": "rules"
+				},
+				"type": "text",
+				"permissionOverwrites": []
+			},
+			{
+				"name": {
+					"PT_BR": "ajuda",
+					"EN": "need-help"
+				},
+				"type": "text",
+				"permissionOverwrites": []
+			},
+			{
+				"name": {
+					"PT_BR": "anúncios",
+					"EN": "announcements"
+				},
+				"type": "text",
+				"permissionOverwrites": []
+			}
+		]
+	};
+	const message = {
+        channel: {
+            send: jest.fn(() => { return 42; })
+        },
+		guild: {
+			roles: {
+				fetch: (() => {
+					return {
+						cache: {
+							find: ((role) => {
+								let array = [
+									{
+										"name": "Mods",
+										"color": "#0985c5",
+										"position": 1,
+										"permissions": 4260888183,
+										"hoist": true,
+										"mentionable": false
+									},
+									{
+										"name": "Member",
+										"color": "#1e8f36",
+										"position": 0,
+										"permissions": 70372929,
+										"hoist": false,
+										"mentionable": true
+									}
+								];
+
+								for (let i = 0; i < array.length; i++) {
+									if (role(array[i])) {
+										return array[i].name;
+									};	
+								}
+							})
+						}
+					}
+				})
+			}
+		}
+    };
+	const parent = {id: 'parentInfo'};
+
+	const channelObj = await templateHandler.adjustChannelObject(channel, 'EN', message, parent);
+	expect(channelObj).toStrictEqual({
+		data: {
+			type: channel.type,
+			permissionOverwrites: [
+				{
+					id: 'Member',
+					allow: [],
+					deny: ['SEND_MESSAGES'],
+				},
+				{
+					id: 'Mods',
+					allow: ['SEND_MESSAGES'],
+					deny: [],
+				}
+			],
+			parent,
+		},
+		child: channel.child
+	});
+});
+
+test('adjustChannelObject - Should return the right object for the channel creation when permissionOverwrites is empty.', async () => {
+	const channel = {
+		"name": {
+			"PT_BR": "Informações",
+			"EN": "Info"
+		},
+		"type": "category",
+		"permissionOverwrites": [],
+		"child": [
+			{
+				"name": {
+					"PT_BR": "bem-vindo",
+					"EN": "welcome"
+				},
+				"type": "text",
+				"permissionOverwrites": []
+			},
+			{
+				"name": {
+					"PT_BR": "regras",
+					"EN": "rules"
+				},
+				"type": "text",
+				"permissionOverwrites": []
+			},
+			{
+				"name": {
+					"PT_BR": "ajuda",
+					"EN": "need-help"
+				},
+				"type": "text",
+				"permissionOverwrites": []
+			},
+			{
+				"name": {
+					"PT_BR": "anúncios",
+					"EN": "announcements"
+				},
+				"type": "text",
+				"permissionOverwrites": []
+			}
+		]
+	};
+	const message = {
+        channel: {
+            send: jest.fn(() => { return 42; })
+        },
+		guild: {
+			roles: {
+				fetch: (() => {
+					return {
+						cache: {
+							find: {}
+						}
+					}
+				})
+			}
+		}
+    };
+	const parent = {id: 'parentInfo'};
+
+	const channelObj = await templateHandler.adjustChannelObject(channel, 'EN', message, parent);
+	expect(channelObj).toStrictEqual({
+		data: {
+			type: channel.type,
+			permissionOverwrites: [],
+			parent,
+		},
+		child: channel.child
+	});
+});
+
+test('adjustChannelObject - should send the right message if any error got catched.', async () => {
+	const channel = {
+		"name": {
+			"PT_BR": "Informações",
+			"EN": "Info"
+		},
+		"type": "category",
+		"permissionOverwrites": [],
+		"child": []
+	};
+	const message = {
+        channel: {
+            send: jest.fn(() => { return 42; })
+        },
+		guild: {
+			roles: {
+				fetch: jest.fn(() => { throw 'ERRROU!'; })
+			}
+		}
+    };
+	const parent = {id: 'parentInfo'};
+
+	await templateHandler.adjustChannelObject(channel, 'EN', message, parent);
+
+	const messageSentSpy = jest.spyOn(message.channel, 'send');
+	expect(messageSentSpy).toHaveBeenCalledWith('Discord API Error on getting roles.');
+});
+
+test('createChannels - expect to call functions the right number of times.', async () => {
+	const channel = [
+		{
+            "name": {
+				"PT_BR": "Informações",
+				"EN": "Info"
+			},
+            "type": "category",
+            "permissionOverwrites": [
+				{
+					"name": {
+						"PT_BR": "Membro",
+						"EN": "Member"
+					},
+					"allow": [],
+					"deny": ["SEND_MESSAGES"]
+				},
+				{
+					"name": {
+						"PT_BR": "Moderação",
+						"EN": "Mods"
+					},
+					"allow": ["SEND_MESSAGES"],
+					"deny": []
+				}
+			],
+            "child": [
+                {
+                    "name": {
+						"PT_BR": "bem-vindo",
+						"EN": "welcome"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "name": {
+						"PT_BR": "regras",
+						"EN": "rules"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "name": {
+						"PT_BR": "ajuda",
+						"EN": "need-help"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                },
+                {
+                    "name": {
+						"PT_BR": "anúncios",
+						"EN": "announcements"
+					},
+                    "type": "text",
+					"permissionOverwrites": []
+                }
+            ]
+        }
+	];
+	const message = {
+        channel: {
+            send: jest.fn(() => { return 42; })
+        },
+		guild: {
+			channels: {
+				create: jest.fn(() => { return 42; })
+			}
+		}
+    };
+
+	const createChannelsSpy = jest.spyOn(templateHandler, 'createChannels');
+	const channelConfigSpy = jest.spyOn(templateHandler, 'adjustChannelObject');
+	const createSpy = jest.spyOn(message.guild.channels, 'create');
+
+	await templateHandler.createChannels(channel, 1, 'EN', message, null, null);
+
+	expect(createSpy).toHaveBeenCalledTimes(5);
+	expect(channelConfigSpy).toHaveBeenCalledTimes(5);
+	expect(createChannelsSpy).toHaveBeenCalledTimes(2);
+});
+
+test('createChannels - expect to call functions the right number of times when it is scalable.', async () => {
+	const message = {
+        channel: {
+            send: jest.fn(() => { return 42; })
+        },
+		guild: {
+			channels: {
+				create: jest.fn(() => { return 42; })
+			}
+		}
+    };
+
+	const createChannelsSpy = jest.spyOn(templateHandler, 'createChannels');
+	const channelConfigSpy = jest.spyOn(templateHandler, 'adjustChannelObject');
+	const createSpy = jest.spyOn(message.guild.channels, 'create');
+
+	await templateHandler.createChannels(DEFAULT_TEMPLATE_JSON.channels, 3, 'EN', message, null, null);
+
+	expect(createSpy).toHaveBeenCalledTimes(25);
+	expect(channelConfigSpy).toHaveBeenCalledTimes(25);
+	expect(createChannelsSpy).toHaveBeenCalledTimes(8);
+});
+
+test('createChannels - should send the right message if any error got catched.', async () => {
+	const message = {
+        channel: {
+            send: jest.fn(() => { return 42; })
+        },
+		guild: {
+			channels: {
+				create: jest.fn(() => { throw 'ERRROU!'; })
+			}
+		}
+    };
+
+	await templateHandler.createChannels(DEFAULT_TEMPLATE_JSON.channels, 3, 'EN', message, null, null);
+
+	const messageSentSpy = jest.spyOn(message.channel, 'send');
+	expect(messageSentSpy).toHaveBeenCalledWith('Discord API Error on creating channels.');
+});
+
+test('executeTemplate - should call the right functions with the respectives params.', async () => {
+	const templateName = 'default';
+	const templateSize = 'small';
+	const templateLang = 'en';
+	const message = {
+        channel: {
+            send: jest.fn(() => { return 42; })
+        }
+    };
+
+	const selectedTemplateSpy = jest.spyOn(templateHandler, 'selectedTemplate');
+	const selectedSizeSpy = jest.spyOn(templateHandler, 'selectedSize');
+	const selectedLangSpy = jest.spyOn(templateHandler, 'selectedLang');
+	const createRolesSpy = jest.spyOn(templateHandler, 'createRoles');
+	const createChannelsSpy = jest.spyOn(templateHandler, 'createChannels');
+
+	await templateHandler.executeTemplate(templateName, templateSize, templateLang, message);
+
+	expect(selectedTemplateSpy).toHaveBeenCalledWith(templateName);
+	expect(selectedSizeSpy).toHaveBeenCalledWith(templateSize);
+	expect(selectedLangSpy).toHaveBeenCalledWith(templateLang);
+	expect(createRolesSpy).toHaveBeenCalledTimes(1);
+	expect(createChannelsSpy).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
I used a recursive approach to get the [new default template](https://github.com/Katreque/bottotherobot/issues/3#issuecomment-832148277) and call the necessary Discord API to create the expected strucure on a Discord server.

Using the **!template** command is a alias to **!template default small en**. The user should change the command params if needed.

Actual templates accepted: **default**.
Actual languages accepted: **pt_br** and **en**.
Actual sizes accepted: **small** (1x), **medium** (2x), **big** (3x) and **giant** (4x).

Tests were fulfilled using a new Discord server and assured with the unit tests.

If this PR were approved, the issues #9, #10, #11 and #17 should be closed.